### PR TITLE
Use irssi server_connect_timeout to set lm timeout

### DIFF
--- a/src/core/xmpp-servers.c
+++ b/src/core/xmpp-servers.c
@@ -169,7 +169,7 @@ xmpp_server_init_connect(SERVER_CONNECT_REC *connrec)
 	lm_connection_set_jid(server->lmconn, recoded);
 	g_free(recoded);
 	lm_connection_set_keep_alive_rate(server->lmconn,
-	    settings_get_time("server_connect_timeout")/1000);
+	    settings_get_time("lag_check_time")/1000);
 
 	server->timeout_tag = 0;
 	server_connect_init((SERVER_REC *)server);

--- a/src/core/xmpp-servers.c
+++ b/src/core/xmpp-servers.c
@@ -168,7 +168,8 @@ xmpp_server_init_connect(SERVER_CONNECT_REC *connrec)
 	recoded = xmpp_recode_out(server->jid);
 	lm_connection_set_jid(server->lmconn, recoded);
 	g_free(recoded);
-	lm_connection_set_keep_alive_rate(server->lmconn, 30);
+	lm_connection_set_keep_alive_rate(server->lmconn,
+	    settings_get_time("server_connect_timeout")/1000);
 
 	server->timeout_tag = 0;
 	server_connect_init((SERVER_REC *)server);


### PR DESCRIPTION
lm timeout was hard coded to 30 sec.
We can instead use the irssi settings server_connect_timeout.