### PR TITLE
fix a comparison between pointer and \0

### DIFF
--- a/src/core/xep/disco.c
+++ b/src/core/xep/disco.c
@@ -69,7 +69,7 @@ disco_request(XMPP_SERVER_REC *server, const char *dest)
 	char *recoded;
 
 	g_return_if_fail(IS_XMPP_SERVER(server));
-	g_return_if_fail(dest != NULL && dest != '\0');
+	g_return_if_fail(dest != NULL && *dest != '\0');
 	recoded = xmpp_recode_out(dest);
 	lmsg = lm_message_new_with_sub_type(recoded, LM_MESSAGE_TYPE_IQ,
 	    LM_MESSAGE_SUB_TYPE_GET);


### PR DESCRIPTION
```
xep/disco.c: In function 'disco_request':
xep/disco.c:72:40: warning: comparison between pointer and zero character constant [-Wpointer-compare]
  g_return_if_fail(dest != NULL && dest != '\0');
                                        ^
/usr/include/glib-2.0/glib/gmacros.h:379:25: note: in definition of macro 'G_LIKELY'
 #define G_LIKELY(expr) (expr)
                         ^~~~
xep/disco.c:72:2: note: in expansion of macro 'g_return_if_fail'
  g_return_if_fail(dest != NULL && dest != '\0');
  ^~~~~~~~~~~~~~~~
xep/disco.c:72:35: note: did you mean to dereference the pointer?
  g_return_if_fail(dest != NULL && dest != '\0');
                                   ^
/usr/include/glib-2.0/glib/gmacros.h:379:25: note: in definition of macro 'G_LIKELY'
 #define G_LIKELY(expr) (expr)
                         ^~~~
xep/disco.c:72:2: note: in expansion of macro 'g_return_if_fail'
  g_return_if_fail(dest != NULL && dest != '\0');
  ^~~~~~~~~~~~~~~~
```