### PR TITLE
disarmed pronouns

### DIFF
--- a/docs/GENERAL
+++ b/docs/GENERAL
@@ -83,10 +83,10 @@ contacts.
 
 /PRESENCE SUBSCRIBE <jid> <reason>
     Sends a subscription request to a JID. If the contact accepts your request,
-    you'll be able to see his/her presence.
+    you'll be able to see their presence.
 
 /PRESENCE UNSUBSCRIBE <jid>
-    Unsubscribes to the contact's presence, so you won't see his/her presence
+    Unsubscribes to the contact's presence, so you won't see their presence
     anymore.
 
 Subscription status:

--- a/src/fe-common/module-formats.c
+++ b/src/fe-common/module-formats.c
@@ -44,9 +44,9 @@ FORMAT_REC fecommon_xmpp_formats[] = {
 	{ NULL, "Subscription", 0, { 0 } },
 
 	{ "suscribe", "$0: wants to subscribe to your presence {comment $1} (accept or deny?)", 2, { 0, 0 } },
-	{ "suscribed", "$0: wants you to see his/her presence", 1, { 0 } },
+	{ "suscribed", "$0: wants you to see their presence", 1, { 0 } },
 	{ "unsuscribe", "$0: doesn't want to see your presence anymore", 1 , { 0 } },
-	{ "unsuscribed", "$0: doesn't want you to see his/her presence anymore", 1 , { 0 } },
+	{ "unsuscribed", "$0: doesn't want you to see their presence anymore", 1 , { 0 } },
 
 	/* ---- */
 	{ NULL, "Message", 0, { 0 } },


### PR DESCRIPTION
This is done in the optimistic pursuit of proper grammar.  The third person pronoun 'they' has existed in English since the 14th century.

https://web.archive.org/web/20061205220746/http://www.aetherlumina.com/gnp/history.html
