### PR TITLE
Add break to switch-statement

### DIFF
--- a/src/fe-common/xep/fe-muc.c
+++ b/src/fe-common/xep/fe-muc.c
@@ -73,6 +73,7 @@ sig_joinerror(MUC_REC *channel, gpointer error)
 		break;
 	case MUC_ERROR_MAXIMUM_USERS_REACHED:
 		reason = "Maximum number of users has been reached";
+		break;
 	default:
 		reason = "Unknown reason";
 	}


### PR DESCRIPTION
Fixes error-message in case MUC_ERROR_MAXIMUM_USERS_REACHED.